### PR TITLE
3D Cube, Disabled element, Search container visibility

### DIFF
--- a/lib/components.pug
+++ b/lib/components.pug
@@ -45,7 +45,7 @@ mixin main-game-list(category, mediadir)
           -
             const imageurl = index =>
               [siteroot, 'media', 'image', category, gameitem, index].join('/')
-          #article-figure-container.image-container: .wrap
+          .image-container: .wrap
             each index in [0, 1, 2, 3]
               +background-image(imageurl(index)).article-figure
 

--- a/lib/components.pug
+++ b/lib/components.pug
@@ -45,7 +45,7 @@ mixin main-game-list(category, mediadir)
           -
             const imageurl = index =>
               [siteroot, 'media', 'image', category, gameitem, index].join('/')
-          #article-figure-container.image-container
+          #article-figure-container.image-container: .wrap
             each index in [0, 1, 2, 3]
               +background-image(imageurl(index)).article-figure
 

--- a/src/script/common-search.js
+++ b/src/script/common-search.js
@@ -22,6 +22,7 @@
     .addEventListener('click', event => {
       event.stopPropagation()
       menuVisibilityCheckbox.checked = false
+      menuVisibilityCheckbox.dispatchEvent(new window.CustomEvent('change'))
       searchTextBox.value || toggleSearchBox()
     }, false)
 

--- a/src/script/lib.js
+++ b/src/script/lib.js
@@ -71,11 +71,22 @@
   const newFirstChild = (parent, child) =>
     parent.insertBefore(child, parent.firstChild)
 
+  const attribute = {
+    string (element, name, value) {
+      value
+        ? element.setAttribute(name, value)
+        : element.removeAttribute(name)
+    },
+    boolean (element, name, value) {
+      attribute.string(element, name, value && name)
+    }
+  }
+
   const lib = freeze({
     donothing,
     onResizeWindow,
     mediaCommonAction,
-    dom: freeze({newFirstChild}),
+    dom: freeze({newFirstChild, attribute}),
     urlParser: {parseHashObject, stringifyHashObject},
     polyfill: freeze({fullscreen}),
     utils: freeze({dashToCamel, capitalize})

--- a/src/script/onload.js
+++ b/src/script/onload.js
@@ -6,5 +6,6 @@
 
   function onDocumentReady () {
     document.body.classList.add('ready-for-transition')
+    document.documentElement.classList.add('javascript-enabled')
   }
 }).call(window, window)

--- a/src/script/onload.js
+++ b/src/script/onload.js
@@ -5,7 +5,17 @@
   document.addEventListener('DOMContentLoaded', onDocumentReady, false)
 
   function onDocumentReady () {
+    const mainSection = document.getElementById('main-section')
+    const menuVisibilityCheckbox = document.getElementById('menu-visibility-checkbox')
+
     document.body.classList.add('ready-for-transition')
     document.documentElement.classList.add('javascript-enabled')
+
+    menuVisibilityCheckbox.addEventListener(
+      'change',
+      () =>
+        window.lib.dom.attribute.boolean(mainSection, 'disabled', menuVisibilityCheckbox.checked),
+      false
+    )
   }
 }).call(window, window)

--- a/src/style/basic.styl
+++ b/src/style/basic.styl
@@ -2,6 +2,10 @@
 hidden, [hidden], .hidden
   display none !important
 
+disabled, [disabled], .disabled
+  &, & *
+    pointer-events none !important
+
 b, strong, .bold, .strong
   font-weight bold !important
 

--- a/src/style/master.styl
+++ b/src/style/master.styl
@@ -491,19 +491,45 @@ body.show-search-box
       html.javascript-enabled &
         .image-container
           position static
-          height fun-std-inner-size(4)
           perspective 1000px
           perspective-origin center
+          height fun-std-inner-size(5)
+
+          .wrap
+            translate = (fun-std-inner-size(4) / 2)
+            position absolute
+            left 0px
+            right 0px
+            margin auto
+            transform-style preserve-3d
+            height fun-std-inner-size(4)
+
+            *
+              backface-visibility hidden
+
+            :nth-child(1)
+              transform translateZ(translate)
+
+            :nth-child(2)
+              transform rotateY(-270deg) translateX(translate)
+              transform-origin top right
+
+            :nth-child(3)
+              transform translateZ(- translate) rotateY(180deg)
+
+            :nth-child(4)
+              transform rotateY(270deg) translateX(- translate)
+              transform-origin center left
 
           .article-figure
             display block
             position absolute
+            height fun-std-inner-size(4)
+            top std-square-size
+            left 0px
+            right 0px
             margin-left auto
             margin-right auto
-            left 0px
-            top 0px
-            right 0px
-            mix-std-inner-rectangle(6, 4)
 
         .controller
           color lime // I don't know what to do with this right now

--- a/src/style/master.styl
+++ b/src/style/master.styl
@@ -484,8 +484,29 @@ body.show-search-box
       .article, .image-container, .article-figure, .content, .game-name, .genre, .paragraph
         display block
 
-      .image-container .article-figure
-        display inline-block
+      html:not(.javascript-enabled) &
+        .image-container .article-figure
+          display inline-block
+
+      html.javascript-enabled &
+        .image-container
+          position static
+          height fun-std-inner-size(4)
+          perspective 1000px
+          perspective-origin center
+
+          .article-figure
+            display block
+            position absolute
+            margin-left auto
+            margin-right auto
+            left 0px
+            top 0px
+            right 0px
+            mix-std-inner-rectangle(6, 4)
+
+        .controller
+          color lime // I don't know what to do with this right now
 
       .image, .background-image, .article-figure
         mix-std-inner-rectangle(4, 3)

--- a/src/style/master.styl
+++ b/src/style/master.styl
@@ -100,7 +100,7 @@ for i in (1..6)
   outline none !important
 
 disabled, [disabled], .disabled
-  filter brightness(0.5)
+  filter brightness(0.5) !important
 
 #main-header, #main-section, #main-footer
   width 100%

--- a/src/style/master.styl
+++ b/src/style/master.styl
@@ -67,6 +67,15 @@ mix-deep-transition()
   &, & *
     mix-transition()
 
+// CSS ASSETS
+
+@keyframes horizontal-spin
+  from
+    transform rotateY(0deg)
+
+  to
+    transform rotateY(-360deg)
+
 // GLOBAL RULES
 
 .ready-for-transition
@@ -503,6 +512,7 @@ body.show-search-box
             margin auto
             transform-style preserve-3d
             height fun-std-inner-size(4)
+            animation horizontal-spin 5s infinite linear
 
             *
               backface-visibility hidden
@@ -530,9 +540,6 @@ body.show-search-box
             right 0px
             margin-left auto
             margin-right auto
-
-        .controller
-          color lime // I don't know what to do with this right now
 
       .image, .background-image, .article-figure
         mix-std-inner-rectangle(4, 3)

--- a/src/style/master.styl
+++ b/src/style/master.styl
@@ -144,6 +144,9 @@ for i in (1..6)
 #search-container, #search-button-container
   right 0px
 
+  html:not(.javascript-enabled) &
+    display none !important
+
 #logo-container
   position absolute
   top 0px

--- a/src/style/master.styl
+++ b/src/style/master.styl
@@ -500,7 +500,7 @@ body.show-search-box
       html.javascript-enabled &
         .image-container
           position static
-          perspective 1000px
+          perspective 750px
           perspective-origin center
           height fun-std-inner-size(5)
 

--- a/src/style/master.styl
+++ b/src/style/master.styl
@@ -99,6 +99,9 @@ for i in (1..6)
 :focus
   outline none !important
 
+disabled, [disabled], .disabled
+  filter brightness(0.5)
+
 #main-header, #main-section, #main-footer
   width 100%
   display block


### PR DESCRIPTION
* If JavaScript is not enabled, `#search-container` would be hidden
  - Element matches `html:not(.javascript-enabled) #search-container` is hidden by default: `display: none`
  - There's a script that adds class `javascript` to `document.documentElement`
  - If JavaScript is blocked, `#search-container` stays hidden

* Opening `#main-menu` would disable `#main-section`
  - Use attribute `disabled`
  - Add basic characteristic of disabled elements
  - Make hidden elements darker

* Create spining 3D cube for each `.article-container`
  - Bring images to center
  - Add a `.wrap` between `.image-container` and its children - `.article-figure`s
  - Only for focused `.article-container`